### PR TITLE
added example to add smallest models to livekit

### DIFF
--- a/lightning/livekit_example/README.md
+++ b/lightning/livekit_example/README.md
@@ -1,6 +1,7 @@
 # Livekit Example
 
-This Example provides scripts and tools to perform standalone audio generation and build livekit voice assistants using the smallest's livekit plugin. Follow the steps below to set up and run the experiments.
+This Example provides scripts and tools to perform standalone audio generation and build livekit voice assistants using the smallest's livekit plugin. Follow the steps below to set up and run the experiments.   
+Please also refer to [smallest.ai](https://smallest.ai) plugin integration PR in the [livekit/agents](https://github.com/livekit/agents/pull/890) repository.  
 
 ## Common Steps
 

--- a/lightning/livekit_example/README.md
+++ b/lightning/livekit_example/README.md
@@ -1,6 +1,6 @@
 # Livekit Example
 
-This project provides scripts and tools to perform audio generation and assist with specific tasks. Follow the steps below to set up and run the project.
+This Example provides scripts and tools to perform standalone audio generation and build livekit voice assistants using the smallest's livekit plugin. Follow the steps below to set up and run the experiments.
 
 ## Common Steps
 
@@ -32,7 +32,16 @@ Once the virtual environment is activated, install the required dependencies:
 pip install -r requirements.txt
 ```
 
-### 3. Create a `.env` File
+### 3. Sign in and create a new project on livekit and copy the following tokens:   
+Sign in here: https://cloud.livekit.io/
+
+```
+LIVEKIT_API_KEY
+LIVEKIT_API_SECRET
+LIVEKIT_URL
+```
+
+### 4. Create a `.env` File
 
 Create a `.env` file in the project root directory. This file should contain the following keys with appropriate values:
 
@@ -45,7 +54,7 @@ DEEPGRAM_API_KEY=...
 SMALLEST_API_KEY=...
 ```
 
-### 4. Install the plugin
+### 5. Install the plugin
 
 To set up the livekit plugin for [smallest.ai](https://smallest.ai)
 
@@ -59,7 +68,7 @@ To set up the livekit plugin for [smallest.ai](https://smallest.ai)
 
 ### 1. Running `generate_audio.py`
 
-To generate audio as a wav file, run the following command:
+To generate audio using the smallest.ai plugin as a wav file, run the following command:
 
 ```bash
 python3 generate_audio.py
@@ -69,16 +78,21 @@ You can change the parameters in the script and try out different voices, langua
 
 ### 2. Running `minimal_assistant.py`
 
-To run the minimal assistant script, use this command:
+To buid a minimal livekit voice assistant using the smallest model, run the following command:
 
 ```bash
-python3 minimal_assistant.py start
-```
+python3 minimal_assistant.py dev
+```  
+  
+### 3. Connect to the agent here:   
+
+https://agents-playground.livekit.io/
+
+
 
 ---
 
 ## Notes
 
 - Ensure that you have added the correct API keys and other credentials in the `.env` file before running the scripts.
-- For any issues or questions, feel free to open an issue in the repository or contact the project maintainers.
-```
+- For any issues or questions, feel free to open an issue in the repository or contact us.

--- a/lightning/livekit_example/README.md
+++ b/lightning/livekit_example/README.md
@@ -1,0 +1,84 @@
+# Livekit Example
+
+This project provides scripts and tools to perform audio generation and assist with specific tasks. Follow the steps below to set up and run the project.
+
+## Common Steps
+
+### 1. Create a Virtual Environment
+
+To ensure your Python environment is isolated, create a virtual environment:
+
+```bash
+python3 -m venv venv
+```
+
+Activate the virtual environment:
+
+- On Linux/Mac:
+  ```bash
+  source venv/bin/activate
+  ```
+
+- On Windows:
+  ```bash
+  venv\Scripts\activate
+  ```
+
+### 2. Install Requirements
+
+Once the virtual environment is activated, install the required dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+### 3. Create a `.env` File
+
+Create a `.env` file in the project root directory. This file should contain the following keys with appropriate values:
+
+```bash
+LIVEKIT_API_KEY=...
+LIVEKIT_API_SECRET=...
+LIVEKIT_URL=...
+OPENAI_API_KEY=...
+DEEPGRAM_API_KEY=...
+SMALLEST_API_KEY=...
+```
+
+### 4. Install the plugin
+
+To set up the livekit plugin for [smallest.ai](https://smallest.ai)
+
+```bash
+./install_plugin.sh
+```
+
+---
+
+## Usage
+
+### 1. Running `generate_audio.py`
+
+To generate audio as a wav file, run the following command:
+
+```bash
+python3 generate_audio.py
+```
+
+You can change the parameters in the script and try out different voices, languages and texts.
+
+### 2. Running `minimal_assistant.py`
+
+To run the minimal assistant script, use this command:
+
+```bash
+python3 minimal_assistant.py start
+```
+
+---
+
+## Notes
+
+- Ensure that you have added the correct API keys and other credentials in the `.env` file before running the scripts.
+- For any issues or questions, feel free to open an issue in the repository or contact the project maintainers.
+```

--- a/lightning/livekit_example/generate_audio.py
+++ b/lightning/livekit_example/generate_audio.py
@@ -1,0 +1,42 @@
+import asyncio
+import aiohttp
+import wave
+from livekit.plugins import smallest, deepgram
+
+from dotenv import load_dotenv
+load_dotenv()
+
+async def test_tts():
+    # Create an aiohttp session
+    async with aiohttp.ClientSession() as session:
+        # Create TTS instance with the session
+        tts = smallest.TTS(
+            http_session=session  # Pass the aiohttp session here
+        )
+
+        # Synthesize text into speech
+        frames = []
+        async for audio in tts.synthesize(text="Hello, this is a test of the TTS system."):
+            frames.append(audio.frame)
+
+        # Save frames to a WAV file
+        with wave.open("output.wav", "wb") as wav_file:
+            wav_file.setnchannels(1)  # Mono audio
+            wav_file.setsampwidth(2)  # 2 bytes per sample (16-bit)
+            wav_file.setframerate(tts._opts.sample_rate)
+            
+            for frame in frames:
+                # Convert the frame data to bytes
+                frame_bytes = frame.data.tobytes()
+                wav_file.writeframes(frame_bytes)
+
+        print("Audio saved to output.wav")
+
+        # Optionally, continue with STT if needed
+        deepgram_stt = deepgram.STT(http_session=session)
+        res = await deepgram_stt.recognize(buffer=frames)
+        print(res)
+
+# Run the async test
+if __name__ == "__main__":
+    asyncio.run(test_tts())

--- a/lightning/livekit_example/generate_audio.py
+++ b/lightning/livekit_example/generate_audio.py
@@ -1,7 +1,7 @@
 import asyncio
 import aiohttp
 import wave
-from livekit.plugins import smallest, deepgram
+from livekit.plugins import smallest
 
 from dotenv import load_dotenv
 load_dotenv()
@@ -31,11 +31,6 @@ async def test_tts():
                 wav_file.writeframes(frame_bytes)
 
         print("Audio saved to output.wav")
-
-        # Optionally, continue with STT if needed
-        deepgram_stt = deepgram.STT(http_session=session)
-        res = await deepgram_stt.recognize(buffer=frames)
-        print(res)
 
 # Run the async test
 if __name__ == "__main__":

--- a/lightning/livekit_example/install_plugin.sh
+++ b/lightning/livekit_example/install_plugin.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [[ -z "$VIRTUAL_ENV" ]]; then
+    echo "You are not in a virtual environment."
+    exit 1
+fi
+
+pip install -e /home/hamees/waves-examples/lightning/livekit_example/livekit-plugins-smallest --config-settings editable_mode=strict

--- a/lightning/livekit_example/install_plugin.sh
+++ b/lightning/livekit_example/install_plugin.sh
@@ -6,4 +6,4 @@ if [[ -z "$VIRTUAL_ENV" ]]; then
     exit 1
 fi
 
-pip install -e /home/hamees/waves-examples/lightning/livekit_example/livekit-plugins-smallest --config-settings editable_mode=strict
+pip install -e ./livekit-plugins-smallest --config-settings editable_mode=strict # change the path accordingly

--- a/lightning/livekit_example/livekit-plugins-smallest/README.md
+++ b/lightning/livekit_example/livekit-plugins-smallest/README.md
@@ -1,0 +1,13 @@
+# LiveKit Plugins Smallest
+
+Agent Framework plugin for voice synthesis with [Smallest](https://smallest.ai/) API.
+
+## Installation
+
+```bash
+pip install livekit-plugins-smallest
+```
+
+## Pre-requisites
+
+You'll need an API key from [smallest.ai](https://waves.smallest.ai/apikeys). It can be set as an environment variable: `SMALLEST_API_KEY`

--- a/lightning/livekit_example/livekit-plugins-smallest/livekit/plugins/smallest/__init__.py
+++ b/lightning/livekit_example/livekit-plugins-smallest/livekit/plugins/smallest/__init__.py
@@ -1,0 +1,38 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .models import TTSEncoding, TTSModels, TTSLanguages, TTSVoices
+from .tts import TTS
+from .version import __version__
+
+__all__ = [
+    "TTS",
+    "TTSEncoding",
+    "TTSModels",
+    "TTSLanguages",
+    "TTSVoices",
+    "__version__",
+]
+
+from livekit.agents import Plugin
+
+from .log import logger
+
+
+class SmallestPlugin(Plugin):
+    def __init__(self):
+        super().__init__(__name__, __version__, __package__, logger)
+
+
+Plugin.register_plugin(SmallestPlugin())

--- a/lightning/livekit_example/livekit-plugins-smallest/livekit/plugins/smallest/log.py
+++ b/lightning/livekit_example/livekit-plugins-smallest/livekit/plugins/smallest/log.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger("livekit.plugins.smallest")

--- a/lightning/livekit_example/livekit-plugins-smallest/livekit/plugins/smallest/models.py
+++ b/lightning/livekit_example/livekit-plugins-smallest/livekit/plugins/smallest/models.py
@@ -1,0 +1,9 @@
+from typing import Literal
+
+TTSEncoding = Literal[
+    "pcm_s16le",
+]
+
+TTSModels = Literal["lightning"]
+TTSLanguages = Literal["en", "hi"]
+TTSVoices = Literal["emily", "jasmine", "arman", "james", "mithali", "aravind", "raj"]

--- a/lightning/livekit_example/livekit-plugins-smallest/livekit/plugins/smallest/tts.py
+++ b/lightning/livekit_example/livekit-plugins-smallest/livekit/plugins/smallest/tts.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import aiohttp
+from livekit.agents import tts, utils
+
+from .log import logger
+from .models import TTSEncoding, TTSLanguages, TTSModels, TTSVoices
+
+API_BASE_URL = "https://waves-api.smallest.ai/api/v1"
+NUM_CHANNELS = 1
+
+@dataclass
+class _TTSOptions:
+    model: TTSModels
+    encoding: TTSEncoding
+    sample_rate: int
+    voice: TTSVoices
+    api_key: str
+    language: TTSLanguages
+    add_wav_header: bool
+
+
+class TTS(tts.TTS):
+    def __init__(
+        self,
+        *,
+        model: TTSModels = "lightning",
+        language: TTSLanguages = "en",
+        encoding: TTSEncoding = "pcm_s16le",
+        voice: TTSVoices = "emily",
+        sample_rate: int = 24000,
+        api_key: str | None = None,
+        add_wav_header: bool = True,
+        http_session: aiohttp.ClientSession | None = None,
+    ) -> None:
+        """
+        Create a new instance of smallest.ai Waves TTS.
+
+        Args:
+            model (TTSModels, optional): The Waves TTS model to use. Defaults to "lightning".
+            language (TTSLanguages, optional): The language code for synthesis. Defaults to "en".
+            encoding (TTSEncoding, optional): The audio encoding format. Defaults to "pcm_s16le".
+            voice (VoiceSettings, optional): The voice settings to use. Defaults to "emily".
+            sample_rate (int, optional): The audio sample rate in Hz. Defaults to 24000.
+            api_key (str, optional): The smallest.ai API key. If not provided, it will be read from the SMALLEST_API_KEY environment variable.
+            add_wav_header (bool, optional): If True, includes a WAV header in the audio output; otherwise, only raw audio data is returned.
+            http_session (aiohttp.ClientSession | None, optional): An existing aiohttp ClientSession to use. If not provided, a new session will be created.
+        """
+
+        super().__init__(
+            capabilities=tts.TTSCapabilities(streaming=False),
+            sample_rate=sample_rate,
+            num_channels=NUM_CHANNELS,
+        )
+
+        api_key = api_key or os.environ.get("SMALLEST_API_KEY")
+        if not api_key:
+            raise ValueError("SMALLEST_API_KEY must be set")
+
+        self._opts = _TTSOptions(
+            model=model,
+            language=language,
+            encoding=encoding,
+            sample_rate=sample_rate,
+            voice=voice,
+            api_key=api_key,
+            add_wav_header=add_wav_header
+        )
+        self._session = http_session
+
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        if not self._session:
+            self._session = utils.http_context.http_session()
+
+        return self._session
+
+    def synthesize(self, text: str) -> "ChunkedStream":
+        return ChunkedStream(text, self._opts, self._ensure_session())
+
+
+class ChunkedStream(tts.ChunkedStream):
+    """Synthesize chunked text using the Waves API endpoint"""
+
+    def __init__(
+        self, text: str, opts: _TTSOptions, session: aiohttp.ClientSession
+    ) -> None:
+        super().__init__()
+        self._text, self._opts, self._session = text, opts, session
+
+    @utils.log_exceptions(logger=logger)
+    async def _main_task(self):
+        bstream = utils.audio.AudioByteStream(
+            sample_rate=self._opts.sample_rate, num_channels=NUM_CHANNELS
+        )
+        request_id, segment_id = utils.shortuuid(), utils.shortuuid()
+
+        data = _to_smallest_options(self._opts)
+        data["text"] = self._text
+
+        url = f"{API_BASE_URL}/{self._opts.model}/get_speech"
+        headers = {
+            "Authorization": f"Bearer {self._opts.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        async with self._session.post(url, headers=headers, json=data) as resp:
+            if resp.status != 200:
+                error_text = await resp.text()
+                raise Exception(f"smallest.ai API error: {resp.status} - {error_text}")
+            
+            async for data, _ in resp.content.iter_chunks():
+                for frame in bstream.write(data):
+                    self._event_ch.send_nowait(
+                        tts.SynthesizedAudio(
+                            request_id=request_id, segment_id=segment_id, frame=frame
+                        )
+                    )
+
+            for frame in bstream.flush():
+                self._event_ch.send_nowait(
+                    tts.SynthesizedAudio(
+                        request_id=request_id, segment_id=segment_id, frame=frame
+                    )
+                )
+
+def _to_smallest_options(opts: _TTSOptions) -> dict[str, Any]:
+    return {
+        "voice_id": opts.voice,
+        "sample_rate": opts.sample_rate,
+        "add_wav_header": opts.add_wav_header,
+    }

--- a/lightning/livekit_example/livekit-plugins-smallest/livekit/plugins/smallest/version.py
+++ b/lightning/livekit_example/livekit-plugins-smallest/livekit/plugins/smallest/version.py
@@ -1,0 +1,15 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "1.0.0"

--- a/lightning/livekit_example/livekit-plugins-smallest/package.json
+++ b/lightning/livekit_example/livekit-plugins-smallest/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "livekit-plugins-smallest",
+    "private": true,
+    "version": "1.0.0"
+  }
+  

--- a/lightning/livekit_example/livekit-plugins-smallest/pyproject.toml
+++ b/lightning/livekit_example/livekit-plugins-smallest/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/lightning/livekit_example/livekit-plugins-smallest/setup.py
+++ b/lightning/livekit_example/livekit-plugins-smallest/setup.py
@@ -1,0 +1,59 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pathlib
+
+import setuptools
+import setuptools.command.build_py
+
+here = pathlib.Path(__file__).parent.resolve()
+about = {}
+with open(
+    os.path.join(here, "livekit", "plugins", "smallest", "version.py"), "r"
+) as f:
+    exec(f.read(), about)
+
+
+setuptools.setup(
+    name="livekit-plugins-smallest",
+    version=about["__version__"],
+    description="LiveKit Agents Plugin for Smallest",
+    long_description=(here / "README.md").read_text(encoding="utf-8"),
+    long_description_content_type="text/markdown",
+    url="https://github.com/livekit/agents",
+    cmdclass={},
+    classifiers=[
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Topic :: Multimedia :: Sound/Audio",
+        "Topic :: Multimedia :: Video",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3 :: Only",
+    ],
+    keywords=["webrtc", "realtime", "audio", "video", "livekit", "smallest"],
+    license="Apache-2.0",
+    packages=setuptools.find_namespace_packages(include=["livekit.*"]),
+    python_requires=">=3.9.0",
+    install_requires=["livekit-agents[codecs]>=0.8.0.dev0"],
+    package_data={"livekit.plugins.smallest": ["py.typed"]},
+    project_urls={
+        "Documentation": "https://docs.livekit.io",
+        "Website": "https://livekit.io/",
+        "Source": "https://github.com/livekit/agents",
+    },
+)

--- a/lightning/livekit_example/minimal_assistant.py
+++ b/lightning/livekit_example/minimal_assistant.py
@@ -1,0 +1,83 @@
+import asyncio
+import logging
+
+from dotenv import load_dotenv
+from livekit import rtc
+from livekit.agents import (
+    AutoSubscribe,
+    JobContext,
+    JobProcess,
+    WorkerOptions,
+    cli,
+    llm,
+    tokenize, 
+    tts
+)
+from livekit.agents.pipeline import VoicePipelineAgent
+from livekit.plugins import deepgram, openai, silero, smallest
+
+load_dotenv()
+logger = logging.getLogger("voice-assistant")
+
+
+def prewarm(proc: JobProcess):
+    proc.userdata["vad"] = silero.VAD.load()
+
+
+async def entrypoint(ctx: JobContext):
+    initial_ctx = llm.ChatContext().append(
+        role="system",
+        text=(
+            "You are a voice assistant created by LiveKit. Your interface with users will be voice. "
+            "You should use short and concise responses, and avoiding usage of unpronouncable punctuation."
+        ),
+    )
+
+    logger.info(f"connecting to room {ctx.room.name}")
+    await ctx.connect(auto_subscribe=AutoSubscribe.AUDIO_ONLY)
+
+    # wait for the first participant to connect
+    participant = await ctx.wait_for_participant()
+    logger.info(f"starting voice assistant for participant {participant.identity}")
+
+    dg_model = "nova-2-general"
+    if participant.kind == rtc.ParticipantKind.PARTICIPANT_KIND_SIP:
+        # use a model optimized for telephony
+        dg_model = "nova-2-phonecall"
+
+    # Since smallest does not support streaming TTS, we can use it with a StreamAdapter (Optional)
+    smallest_tts = tts.StreamAdapter(
+        tts=smallest.TTS(),
+        sentence_tokenizer=tokenize.basic.SentenceTokenizer(),
+    )
+
+    agent = VoicePipelineAgent(
+        vad=ctx.proc.userdata["vad"],
+        stt=deepgram.STT(model=dg_model),
+        llm=openai.LLM(),
+        tts=smallest.TTS(), # replace with smallest_tts to use smallest with streaming
+        chat_ctx=initial_ctx,
+    )
+
+    agent.start(ctx.room, participant)
+
+    # listen to incoming chat messages, only required if you'd like the agent to
+    # answer incoming messages from Chat
+    chat = rtc.ChatManager(ctx.room)
+
+    async def answer_from_text(txt: str):
+        chat_ctx = agent.chat_ctx.copy()
+        chat_ctx.append(role="user", text=txt)
+        stream = agent.llm.chat(chat_ctx=chat_ctx)
+        await agent.say(stream)
+
+    @chat.on("message_received")
+    def on_chat_received(msg: rtc.ChatMessage):
+        if msg.message:
+            asyncio.create_task(answer_from_text(msg.message))
+
+    await agent.say("Hey, how can I help you today?", allow_interruptions=True)
+
+
+if __name__ == "__main__":
+    cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint, prewarm_fnc=prewarm))

--- a/lightning/livekit_example/minimal_assistant.py
+++ b/lightning/livekit_example/minimal_assistant.py
@@ -45,7 +45,7 @@ async def entrypoint(ctx: JobContext):
         # use a model optimized for telephony
         dg_model = "nova-2-phonecall"
 
-    # Since smallest does not support streaming TTS, we can use it with a StreamAdapter (Optional)
+    # Since lightning model does not natively support streaming TTS, we can use it with a StreamAdapter (Optional)
     smallest_tts = tts.StreamAdapter(
         tts=smallest.TTS(),
         sentence_tokenizer=tokenize.basic.SentenceTokenizer(),

--- a/lightning/livekit_example/requirements.txt
+++ b/lightning/livekit_example/requirements.txt
@@ -1,0 +1,6 @@
+livekit-agents>=0.10.1
+livekit-plugins-openai>=0.10.3
+livekit-plugins-deepgram>=0.6.8
+livekit-plugins-silero>=0.7.1
+python-dotenv~=1.0
+aiofile~=3.8.8


### PR DESCRIPTION
#2  support for smallest models in livekit, example code to test it

- `generate_audio.py` generates standalone audio of given text using the smallest plugin, in case anyone wants to hear the audios.
- `minimal_assistant.py` builds a minimal livekit voice assistant with smallest models as tts, with optional streaming support using streamadapter.